### PR TITLE
allow family to bet set to 0 to align with nodejs api

### DIFF
--- a/src/Lookup.js
+++ b/src/Lookup.js
@@ -90,12 +90,13 @@ class Lookup {
                 this._resolve(hostname, options).then(resultCb, callback);
 
                 break;
+            case 0:
             case undefined:
                 this._resolveBoth(hostname, options).then(resultCb, callback);
 
                 break;
             default:
-                throw new Error('invalid family number, must be one of the {4, 6} or undefined');
+                throw new Error('invalid family number, must be one of the {0, 4, 6} or undefined');
         }
     }
 


### PR DESCRIPTION
>family <integer> The record family. Must be 4, 6, or 0. The value 0 indicates that IPv4 and IPv6 addresses are both returned. Default: 0.
> -- https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback